### PR TITLE
Change constraint formatting. Chef 11 compatibility

### DIFF
--- a/lib/chef/knife/sharp-align.rb
+++ b/lib/chef/knife/sharp-align.rb
@@ -138,7 +138,8 @@ module KnifeSharp
           end
 
           if all or answer == "Y"
-            env.cookbook_versions[cb] = version
+            # Force "= a.b.c" in cookbook version, as chef11 will not accept "a.b.c"
+            env.cookbook_versions[cb] = "= #{version}"
             bumped << @loader[cb]
           else
             ui.msg "* Skipping #{cb} cookbook"

--- a/lib/knife-sharp.rb
+++ b/lib/knife-sharp.rb
@@ -1,3 +1,3 @@
 module KnifeSharp
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end


### PR DESCRIPTION
With Chef 11 server will not accept version "x.y.z" in cookbook alignment. "= x.y.z" is mandatory. This is compatible with chef 10.x also
