### PR TITLE
Add SSL CA verifications options for bot notification

### DIFF
--- a/ext/sharp-config.yml
+++ b/ext/sharp-config.yml
@@ -20,6 +20,10 @@ notification:
     username: "Nicolas"
     # don't notify if updates are done on development chef
     skip: [dev]
+    # Set to :none to skip CA cert checking
+    ssl_verify_mode: :verify
+    # Optional path to CA file
+    ssl_ca_file: "~/.chef/my-ca.pem"
 
 # ignore cookbooks/data bags/roles depending on chef server
 # key is the name of your server (in a knife sharp server sense)

--- a/lib/knife-sharp.rb
+++ b/lib/knife-sharp.rb
@@ -1,3 +1,3 @@
 module KnifeSharp
-  VERSION = "0.6.3"
+  VERSION = "0.7.0"
 end

--- a/lib/knife-sharp/common.rb
+++ b/lib/knife-sharp/common.rb
@@ -112,6 +112,8 @@ module KnifeSharp
           notif = "chef: #{message} by #{config["username"]}"
           http = Net::HTTP.new(uri.host, uri.port)
           http.use_ssl = (uri.scheme == "https")
+          http.verify_mode = OpenSSL::SSL::VERIFY_NONE if config["ssl_verify_mode"] == :none
+          http.ca_file = File.expand_path(config["ssl_ca_file"]) if config["ssl_ca_file"]
           http.post(uri.path, "message=#{notif}")
         rescue Exception => e
           ui.error "Unable to notify via bot. #{e.message}"
@@ -133,4 +135,3 @@ module KnifeSharp
     end
   end
 end
-


### PR DESCRIPTION
Adds options `ssl_verify_mode` which can be set to `:none` or `:verify` (the default) and `ssl_ca_file` to point at a CA cert. This allows you to use bot notifications if you're using a self-signed or internal CA. Fixes #54.

Before: 
```
$ knife sharp align  ...
ERROR: Unable to notify via bot. SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)
```

After:

Bot notified
